### PR TITLE
Added enpoint for creating service tickets

### DIFF
--- a/Models/DTOs/ServiceTicketDTO.cs
+++ b/Models/DTOs/ServiceTicketDTO.cs
@@ -7,7 +7,7 @@ public class ServiceTicketDTO
     public int? EmployeeId { get; set;}
     public string Description { get; set;}
     public bool Emergency { get; set;}
-    public DateTime DateCompleted { get; set;}
+    public DateTime? DateCompleted { get; set;}
     public EmployeeDTO Employee { get; set; }
     public CustomerDTO Customer { get; set; }
 }

--- a/Models/ServiceTicket.cs
+++ b/Models/ServiceTicket.cs
@@ -7,7 +7,7 @@ public class ServiceTicket
     public int? EmployeeId { get; set;}
     public string Description { get; set;}
     public bool Emergency { get; set;}
-    public DateTime DateCompleted { get; set;}
+    public DateTime? DateCompleted { get; set;}
     public Employee Employee { get; set; }
     public Customer Customer { get; set; }
 

--- a/Program.cs
+++ b/Program.cs
@@ -175,5 +175,37 @@ app.MapGet("/employees/{id}", (int id) =>
     });
 });
 
+// Creates a service ticket -- POST
+app.MapPost("/servicetickets", (ServiceTicket serviceTicket) =>
+{
+    // Get the customer data to check that the customerid for the service ticket is valid
+    Customer customer = customers.FirstOrDefault(c => c.Id == serviceTicket.CustomerId);
+
+    // if the client did not provide a valid customer id, this is a bad request
+    if (customer == null)
+    {
+        return Results.BadRequest();
+    }
+
+    // creates a new id (SQL will do this for us like JSON server did!)
+    serviceTicket.Id = serviceTickets.Max(st => st.Id) + 1;
+    serviceTickets.Add(serviceTicket);
+
+    // Created returns a 201 status code with a link in the headers to where the new resource can be accessed
+    return Results.Created($"/servicetickets/{serviceTicket.Id}", new ServiceTicketDTO
+    {
+        Id = serviceTicket.Id,
+        CustomerId = serviceTicket.CustomerId,
+        Customer = new CustomerDTO
+        {
+            Id = customer.Id,
+            Name = customer.Name,
+            Address = customer.Address
+        },
+        Description = serviceTicket.Description,
+        Emergency = serviceTicket.Emergency
+    });
+});
+
 //! This starts the app, and should always be at the bottom of this file.
 app.Run();


### PR DESCRIPTION
## Description

This pull request adds a new endpoint to the HoneyRaesAPI project for creating service tickets. The endpoint allows clients to post new service tickets to the database, ensuring that the customer ID provided is valid and generating a new ID for the service ticket.

## Changes Made

### Adding the POST Endpoint for Service Tickets

- Added a new `MapPost` endpoint in `Program.cs` for creating service tickets.
- The endpoint checks if the provided customer ID is valid before creating the service ticket.
- Generates a new ID for the service ticket and adds it to the database.
- Returns a `201 Created` status code with the new service ticket data.

## How to Test

1. Start the API server and ensure it's running.
2. Open Postman and create a new POST request to `http://localhost:<port>/servicetickets`.
3. In the request body, add a JSON object with the following format:

   ```json
   {
       "customerId": <valid_customer_id>,
       "description": "<description_of_the_issue>",
       "emergency": <true_or_false>
   }
