### PR TITLE
Added endpoint for deleting a service ticket

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -207,5 +207,19 @@ app.MapPost("/servicetickets", (ServiceTicket serviceTicket) =>
     });
 });
 
+// Deletes a service ticket
+app.MapDelete("/servicetickets/{id}", (int id) =>
+{
+    ServiceTicket serviceTicket = serviceTickets.FirstOrDefault(st => st.Id == id);
+
+    if (serviceTicket == null)
+    {
+        return Results.NotFound();
+    }
+
+    serviceTickets.RemoveAt(id - 1);
+    return Results.NoContent();
+});
+
 //! This starts the app, and should always be at the bottom of this file.
 app.Run();


### PR DESCRIPTION
## Description

This pull request adds a new endpoint to the HoneyRaesAPI project for deleting service tickets. The endpoint allows clients to delete existing service tickets from the database by specifying the service ticket ID.

## Changes Made

### Adding the DELETE Endpoint for Service Tickets

- Added a new `MapDelete` endpoint in `Program.cs` for deleting service tickets.
- The endpoint uses a route parameter `{id}` to capture the ID of the service ticket to delete.
- The handler's logic removes the service ticket from the database that matches the provided ID.
- The endpoint returns a `204 No Content` status code upon successful deletion.

## How to Test

1. Start the API server and ensure it's running.
2. Open Postman and create a new DELETE request to `http://localhost:5240/servicetickets/{id}`, replacing `{id}` with the ID of the service ticket you want to delete.
3. Send the request and check the response status code. It should be `204 No Content`.
4. Send a GET request to `http://localhost:5240/servicetickets` to verify that the deleted service ticket is no longer in the database.
5. Optionally, send a GET request to `http://localhost:5240/servicetickets/{id}` using the same ID as in step 2 to confirm that the request now returns a `404 Not Found` status code.